### PR TITLE
CSS fix for short and long labels

### DIFF
--- a/trelabels.css
+++ b/trelabels.css
@@ -70,7 +70,8 @@
   height: inherit;
   line-height: 1;
   width: inherit;
-  max-width: 100%;
+  min-width: inherit;
+  max-width: 230px;
   padding: 2px 4px;
   border-radius: 3px;
   margin: 0 2px 3px 0;


### PR DESCRIPTION
Two style fixes for the "Tags" option:

1) Resets min-width for very short labels, so they don't consume unnecessary space.

2) Very long label names don't cause a horizontal scrollbar anymore.

Previous: 
![02_trelabel-current](https://user-images.githubusercontent.com/2011264/29063240-48cce598-7c25-11e7-9f95-ab055b07ab98.png)

Now:
![03_trelabel-fix](https://user-images.githubusercontent.com/2011264/29063244-4b2d5e62-7c25-11e7-87ab-1fa1b9b332c5.png)
